### PR TITLE
Extract marked config and update dashboard UI

### DIFF
--- a/src/components/layouts/Markdown.svelte
+++ b/src/components/layouts/Markdown.svelte
@@ -1,9 +1,7 @@
 <script lang="ts">
-  import { marked } from 'marked'
-  import { markedHighlight } from 'marked-highlight'
-  import markedAlert from 'marked-alert'
   import DOMPurify from 'isomorphic-dompurify'
-  import hljs from 'highlight.js'
+  import { onMount } from 'svelte'
+  import { getMarked } from '$lib/utils/marked'
 
   interface Props {
     source: string
@@ -11,42 +9,18 @@
 
   let { source }: Props = $props()
 
-  marked.use(
-    markedHighlight({
-      langPrefix: 'hljs language-',
-      highlight(code, lang) {
-        const language = hljs.getLanguage(lang) ? lang : 'plaintext'
-        return hljs.highlight(code, { language }).value
-      }
-    })
-  )
-
-  marked.use(
-    markedAlert({
-      variants: [
-        { icon: '', type: 'note' },
-        { icon: '', type: 'tip' },
-        { icon: '', type: 'important' },
-        { icon: '', type: 'warning' },
-        { icon: '', type: 'caution' }
-      ]
-    })
-  )
-
-  marked.use({
-    breaks: true,
-    gfm: true
-  })
-
+  const parser = getMarked()
   const purifyConfig = {
     ADD_TAGS: ['span', 'div', 'p', 'pre', 'code'],
     ADD_ATTR: ['class', 'style'],
     FORBID_ATTR: ['style', 'onerror', 'onload']
   }
+
+  onMount(() => {})
 </script>
 
 <div class="markdown-body">
-  {@html DOMPurify.sanitize(marked.parse(source) as string, purifyConfig)}
+  {@html DOMPurify.sanitize(parser.parse(source) as string, purifyConfig)}
 </div>
 
 <style lang="scss" global>
@@ -160,7 +134,6 @@
 
     pre {
       overflow-x: auto;
-      max-width: 100%;
       margin: 0;
 
       code.hljs {

--- a/src/lib/utils/marked.ts
+++ b/src/lib/utils/marked.ts
@@ -1,0 +1,42 @@
+import { marked } from 'marked'
+import { markedHighlight } from 'marked-highlight'
+import markedAlert from 'marked-alert'
+import hljs from 'highlight.js'
+
+let configured = false
+
+export function getMarked() {
+  if (!configured) {
+    marked.use(
+      markedHighlight({
+        langPrefix: 'hljs language-',
+        highlight(code, lang) {
+          const language = hljs.getLanguage(lang) ? lang : 'plaintext'
+          return hljs.highlight(code, { language }).value
+        }
+      })
+    )
+
+    marked.use(
+      markedAlert({
+        variants: [
+          { icon: '', type: 'note' },
+          { icon: '', type: 'tip' },
+          { icon: '', type: 'important' },
+          { icon: '', type: 'warning' },
+          { icon: '', type: 'caution' }
+        ]
+      })
+    )
+
+    marked.use({
+      breaks: true,
+      gfm: true
+    })
+
+    configured = true
+  }
+
+  return marked
+}
+

--- a/src/routes/(app)/dashboard/+layout.svelte
+++ b/src/routes/(app)/dashboard/+layout.svelte
@@ -27,7 +27,7 @@
     <LeftPanel bind:leftPanelOpen />
   </div>
 
-  <div class="content">
+  <div class="content" class:full-width={!leftPanelOpen}>
     {@render children?.()}
     <Footer />
   </div>
@@ -43,11 +43,13 @@
 
   div.nav {
     width: 260px;
+    min-width: 260px;
     transition: all 0.3s;
     z-index: 10;
 
     &.closed {
       width: 106px;
+      min-width: 106px;
     }
   }
 
@@ -55,5 +57,10 @@
     padding: 30px 100px;
     flex: 1;
     position: relative;
+    width: calc(100vw - 460px);
+
+    &.full-width {
+      width: calc(100vw - 306px);
+    }
   }
 </style>

--- a/src/routes/(app)/dashboard/+page.svelte
+++ b/src/routes/(app)/dashboard/+page.svelte
@@ -134,47 +134,59 @@
       </p>
     </div>
   </div>
-  <section class="section">
+  <div class="news">
     {#await data.streamed.fetchNews}
-      <p>Loading...</p>
+      <section class="section">
+        <p>Loading...</p>
+      </section>
     {:then news}
       {#each news.filter(filterPosts) as post}
-        <article class="blog-post">
-          <header class="post-header">
-            <div class="meta-tags">
-              <span class="date">
-                <i class="fa-solid fa-calendar"></i>
-                {new Date(post.date).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
-              </span>
-              {#if post.author}
-                <span class="author">
-                  <i class="fa-solid fa-user"></i>
-                  {post.author}
+        <section class="section">
+          <article class="blog-post">
+            <header class="post-header">
+              <div class="meta-tags">
+                <span class="date">
+                  <i class="fa-solid fa-calendar"></i>
+                  {new Date(post.date).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
                 </span>
-              {/if}
-              {#if post.tags}
-                <div class="tags">
-                  {#each post.tags as tag}
-                    <span class="tag">#{tag}</span>
-                  {/each}
-                </div>
-              {/if}
+                {#if post.author}
+                  <span class="author">
+                    <i class="fa-solid fa-user"></i>
+                    {post.author}
+                  </span>
+                {/if}
+                {#if post.tags}
+                  <div class="tags">
+                    {#each post.tags as tag}
+                      <span class="tag">#{tag}</span>
+                    {/each}
+                  </div>
+                {/if}
+              </div>
+
+              <h2 class="post-title">{post.title}</h2>
+            </header>
+
+            {#if post.hero}
+              <div class="hero" style="background-image: url('https://emlproject.pages.dev{post.hero}')"></div>
+            {/if}
+
+            <div class="doc-content">
+              <Markdown source={post.content} />
             </div>
-
-            <h2 class="post-title">{post.title}</h2>
-          </header>
-
-          <div class="doc-content">
-            <Markdown source={post.content} />
-          </div>
-        </article>
+          </article>
+        </section>
       {:else}
-        <p>{$l.dashboard.noNews}</p>
+        <section class="section">
+          <p>{$l.dashboard.noNews}</p>
+        </section>
       {/each}
     {:catch error}
-      <p>{$l.dashboard.noNews}</p>
+      <section class="section">
+        <p>{$l.dashboard.noNews}</p>
+      </section>
     {/await}
-  </section>
+  </div>
 </div>
 
 <style lang="scss">
@@ -196,12 +208,21 @@
     flex-direction: column;
   }
 
+  div.news {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 25px;
+    overflow: hidden;
+  }
+
   section.section {
     flex: 1;
     margin-top: 0;
     display: flex;
     gap: 30px;
     flex-direction: column;
+    position: relative;
 
     .blog-post {
       &:not(:last-child) {
@@ -211,7 +232,8 @@
     }
 
     .post-header {
-      margin-bottom: 2rem;
+      max-width: 800px;
+      margin: 0 auto 30px auto;
 
       h2.post-title {
         font-size: 2rem;
@@ -249,6 +271,23 @@
           font-weight: 600;
         }
       }
+    }
+
+    div.hero {
+      width: 100%;
+      max-width: 800px;
+      margin: 0 auto 30px auto;
+      aspect-ratio: 3 / 2;
+      background-size: cover;
+      background-position: center;
+      border-radius: 10px;
+      box-shadow: 0 4px 20px #00000026;
+      border: 1px solid var(--border-color, #333);
+    }
+
+    div.doc-content {
+      max-width: 800px;
+      margin: 0 auto;
     }
   }
 


### PR DESCRIPTION
Move marked configuration into a reusable util (src/lib/utils/marked.ts) and make Markdown.svelte use getMarked() + DOMPurify for parsing/sanitizing instead of configuring marked inline. Adjust dashboard layout and styles to support a collapsible left panel (add full-width class, min-widths, and width calc changes), restructure the news list into section wrappers, add hero image support for posts, and center/limit post content width.