### PR TITLE
rm docker socket from web ct (restore #230 fix reverted in v2.4.0)

### DIFF
--- a/.github/templates/docker-compose.prod.yml
+++ b/.github/templates/docker-compose.prod.yml
@@ -36,7 +36,6 @@ services:
     volumes:
       - files:/app/files
       - env:/app/env
-      - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - '8080:3000'
     depends_on:
@@ -64,7 +63,7 @@ services:
       - ./docker-compose.prod.yml:/app/compose/docker-compose.prod.yml
       - ./.env:/app/compose/.env:ro
       - env:/app/env:ro
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       - web
     labels:

--- a/.github/templates/docker-compose.prod.yml
+++ b/.github/templates/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
     volumes:
       - files:/app/files
       - env:/app/env
+      - data:/app/data
     ports:
       - '8080:3000'
     depends_on:

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -14,8 +14,6 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-RUN apk add --no-cache docker-cli
-
 COPY --from=build /app/dist .
 COPY --from=build /app/dist-scripts ./migration-scripts
 COPY --from=build /app/env ./env

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -4,8 +4,6 @@ WORKDIR /app
 
 ENV CHOKIDAR_USEPOLLING=true
 
-RUN apk add --no-cache docker-cli
-
 COPY package.json ./
 COPY prisma.config.ts ./
 COPY docker/entrypoint.dev.sh ./

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -47,7 +47,6 @@ services:
       - ../vite.config.ts:/app/vite.config.ts
       - ../files:/app/files
       - ../data:/app/data
-      - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - '5173:5173'
     depends_on:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -36,7 +36,6 @@ services:
     volumes:
       - files:/app/files
       - env:/app/env
-      - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - '8080:3000'
     depends_on:
@@ -64,7 +63,7 @@ services:
       - ./docker-compose.prod.yml:/app/compose/docker-compose.prod.yml
       - ./.env:/app/compose/.env:ro
       - env:/app/env:ro
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       - web
     labels:

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -36,6 +36,7 @@ services:
     volumes:
       - files:/app/files
       - env:/app/env
+      - data:/app/data
     ports:
       - '8080:3000'
     depends_on:


### PR DESCRIPTION
## what is that

restores the #230 fix that was reverted by the v2.4.0 release commit (f047117), + extends it to the files that never received it:

- **`docker/docker-compose.prod.yml`** remove the docker socket mount from `web`, mount it `:ro` on `upd` (this is exactly what 954ba98 / #232 did)
- **`.github/templates/docker-compose.prod.yml`** same change; this template is what the installer ships + it never got the original fix
- **`docker/docker-compose.dev.yml`** remove the socket from `web` (dev `upd` already runs w/ out it, in mock mode)
- **`docker/Dockerfile.build` + `docker/Dockerfile.dev`** drop the unused `docker-cli` package (leftover from the pre-watchtower update system, 09a92c6; nothing in the shipped image invokes it...)

fixes #237, re-fixes #230

## why, again (copy-paste)

`web` is the internet-facing ct. a rw docker socket inside it turns any rce in it into root on the host. the app makes zero use of the docker api: restarts are `process.exit(0)` + `restart: unless-stopped`, and updates go through http calls to `upd` (`src/lib/server/setup.ts`, `src/lib/server/update.ts`)

the socket stays on `upd` (rw capability is inherent to its job, it `docker inspect`s itself and `docker run`s an ephemeral agent that executes `docker compose pull && up -d`). note that `:ro` does not restrict docker api access (write api calls work through a `:ro` socket mount); it is restored here because it matches the previously accepted fix and costs nothing... :(

## verification

tested against the 2.4.0 images w/ this exact compose configuration

- setup wizard completes (db init, admin user, pin)
- server restart works (ct exits and self-restarts via restart policy)
- updater reload works (`✅ Token updated successfully` in `upd` logs, through the `:ro` socket)
- storage stats and update check work
- `grep -r docker.sock /app` inside the shipped `web` image: zero references
- counterfactual: w/ no socket on `upd`, `POST /update` fails (`Failed to inspect self`), confirming `upd` is the one and only service that needs the mount
- `docker compose config -q` passes on all three modified compose files
